### PR TITLE
Fix some dependency vulnerability + setFailed message

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3515,7 +3515,7 @@ function run() {
             yield installer.getOpam(ocaml_version);
         }
         catch (error) {
-            core.setFailed(error.message);
+            core.setFailed(error.toString());
         }
     });
 }

--- a/src/setup-ocaml.ts
+++ b/src/setup-ocaml.ts
@@ -7,7 +7,7 @@ async function run() {
     let ocaml_version = core.getInput('ocaml-version');
     await installer.getOpam(ocaml_version);
   } catch (error) {
-    core.setFailed(error.message);
+    core.setFailed(error.toString());
   }
 }
 


### PR DESCRIPTION
Strings are thrown inside `install.ts`, so when they're getting caught, `error.message` is undefined. Using `error.toString()` instead, which will do nothing on string and print something anyway with exceptions

Also, npm advised to update the dependencies (using npm audit fix) so that's what I did, but I can revert the commit if you prefer :)