### PR TITLE
Fix action name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: Setup OCaml
+name: Set up OCaml
 description: Set up an OCaml and opam environment and add to PATH
 author: Anil Madhavapeddy
 branding:


### PR DESCRIPTION
Along the same lines as the description. An alternative would be "OCaml Setup." See https://grammarist.com/spelling/set-up-vs-setup/.