### PR TITLE
Add parameter to select default opam repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,61 +132,65 @@ offer several methods to do this.
 For example, using the strategy matrix:
 
 ```yml
-runs-on: ${{ matrix.os }}
 strategy:
   matrix:
-    os: [macos-latest, windows-latest, ubuntu-latest]
+    os:
+      - macos-latest
+      - ubuntu-latest
+      - windows-latest
     include:
       - os: macos-latest
-         opam-repo: https://github.com/ocaml/opam-repository.git
+        opam-repo: https://github.com/ocaml/opam-repository.git
       - os: ubuntu-latest
-         opam-repo: https://github.com/ocaml/opam-repository.git
+        opam-repo: https://github.com/ocaml/opam-repository.git
       - os: windows-latest
-         opam-repo: https://github.com/fdopen/opam-repository-mingw.git#opam2
-steps
-    - name: Use OCaml with repo ${{ matrix.opam-repo }}
-      uses: avsm/setup-ocaml@v1
-      with:
-        opam-repository: ${{ matrix.opam-repo }}
+        opam-repo: https://github.com/fdopen/opam-repository-mingw.git#opam2
+
+runs-on: ${{ matrix.os }}
+
+steps:
+  - name: Use OCaml with repo ${{ matrix.opam-repo }}
+    uses: avsm/setup-ocaml@v1
+    with:
+      opam-repository: ${{ matrix.opam-repo }}
 ```
 
 Using a custom step to choose between the values:
 
 ```yml
-jobs:
-  build:
-    runs-on: [macos-latest, windows-latest, ubuntu-latest]
-    steps:
-      - id: repo
-        run: |
-          if [ "$RUNNER_OS" == "Windows" ] ; then
-            echo "::set-output name=url::https://github.com/fdopen/opam-repository-mingw.git#opam2"
-          elif [ "$RUNNER_OS" == "macOS" ] ; then
-            echo "::set-output name=url::https://github.com/custom/opam-repository-mingw.git#macOS"
-          else
-            echo "::set-output name=url::https://github.com/ocaml/opam-repository.git"
-          fi
-        shell: bash
-      - name: Use OCaml with repo ${{ steps.repo.url }}
-        uses: avsm/setup-ocaml@v1
-        with:
-          opam-repository: ${{ steps.repo.url }}
+steps:
+  - id: repo
+    shell: bash
+    run: |
+      if [ "$RUNNER_OS" == "Windows" ]; then
+        echo "::set-output name=url::https://github.com/fdopen/opam-repository-mingw.git#opam2"
+      elif [ "$RUNNER_OS" == "macOS" ]; then
+        echo "::set-output name=url::https://github.com/custom/opam-repository-mingw.git#macOS"
+      else
+        echo "::set-output name=url::https://github.com/ocaml/opam-repository.git"
+      fi
+
+  - name: Use OCaml with repo ${{ steps.repo.url }}
+    uses: avsm/setup-ocaml@v1
+    with:
+      opam-repository: ${{ steps.repo.url }}
 ```
 
 Using several conditional setup steps:
 
 ```yml
 steps:
-  - name: Use OCaml on windows
+  - name: Use OCaml on Windows
     uses: avsm/setup-ocaml@v1
     if: ${{ runner.os == 'Windows' }}
     with:
-      ocaml-repository: "https://github.com/fdopen/opam-repository-mingw.git#opam2"
-  - name: Use OCaml on unix
+      ocaml-repository: https://github.com/fdopen/opam-repository-mingw.git#opam2
+
+  - name: Use OCaml on Unix
     uses: avsm/setup-ocaml@v1
     if: ${{ runner.os != 'Windows' }}
     with:
-      opam-repository: "https://github.com/ocaml/opam-repository.git"
+      opam-repository: https://github.com/ocaml/opam-repository.git
 ```
 
 ## Roadmap

--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -25,6 +25,13 @@ describe("installer tests", () => {
   }, 100000);
 
   it("Acquires opam source", async () => {
-    await installer.getOpam("2.0.5");
+    await installer.getOpam("2.0.5", "");
+  }, 1000000);
+
+  it("Acquires opam source and uses custom repository", async () => {
+    await installer.getOpam(
+      "2.0.5",
+      "https://github.com/ocaml/opam-repository.git#master"
+    );
   }, 1000000);
 });

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   ocaml-version:
     description: Version of the OCaml compiler to initialise
     default: 4.08.1
+  opam-repository:
+    description: URL of the repository to fetch packages from
+    default: ""
 runs:
   using: "node12"
   main: "lib/index.js"

--- a/lib/index.js
+++ b/lib/index.js
@@ -4719,15 +4719,15 @@ function getOpamFileName(version) {
 function getOpamDownloadUrl(version, filename) {
     return util.format("https://github.com/ocaml/opam/releases/download/%s/%s", version, filename);
 }
-function acquireOpamWindows(version, custom_repository) {
+function acquireOpamWindows(version, customRepository) {
     return __awaiter(this, void 0, void 0, function () {
         var repository, downloadPath, error_1, toolPath;
         return __generator(this, function (_a) {
             switch (_a.label) {
                 case 0:
-                    repository = custom_repository === ""
+                    repository = customRepository === ""
                         ? "https://github.com/fdopen/opam-repository-mingw.git#opam2"
-                        : custom_repository;
+                        : customRepository;
                     _a.label = 1;
                 case 1:
                     _a.trys.push([1, 3, , 4]);
@@ -4757,7 +4757,7 @@ function acquireOpamWindows(version, custom_repository) {
         });
     });
 }
-function acquireOpamLinux(version, custom_repository) {
+function acquireOpamLinux(version, customRepository) {
     return __awaiter(this, void 0, void 0, function () {
         var opamVersion, fileName, downloadUrl, repository, downloadPath, error_2, toolPath;
         return __generator(this, function (_a) {
@@ -4766,9 +4766,9 @@ function acquireOpamLinux(version, custom_repository) {
                     opamVersion = "2.0.5";
                     fileName = getOpamFileName(opamVersion);
                     downloadUrl = getOpamDownloadUrl(opamVersion, fileName);
-                    repository = custom_repository === ""
+                    repository = customRepository === ""
                         ? "https://github.com/ocaml/opam-repository.git"
-                        : custom_repository;
+                        : customRepository;
                     _a.label = 1;
                 case 1:
                     _a.trys.push([1, 3, , 4]);
@@ -4803,15 +4803,15 @@ function acquireOpamLinux(version, custom_repository) {
         });
     });
 }
-function acquireOpamDarwin(version, custom_repository) {
+function acquireOpamDarwin(version, customRepository) {
     return __awaiter(this, void 0, void 0, function () {
         var repository;
         return __generator(this, function (_a) {
             switch (_a.label) {
                 case 0:
-                    repository = custom_repository === ""
+                    repository = customRepository === ""
                         ? "https://github.com/ocaml/opam-repository.git"
-                        : custom_repository;
+                        : customRepository;
                     return [4 /*yield*/, exec_1.exec("brew", ["install", "opam"])];
                 case 1:
                     _a.sent();

--- a/lib/index.js
+++ b/lib/index.js
@@ -4307,13 +4307,14 @@ var core = __webpack_require__(470);
 var installer = __webpack_require__(923);
 function run() {
     return __awaiter(this, void 0, void 0, function () {
-        var ocamlVersion, error_1;
+        var ocamlVersion, opamRepository, error_1;
         return __generator(this, function (_a) {
             switch (_a.label) {
                 case 0:
                     _a.trys.push([0, 2, , 3]);
                     ocamlVersion = core.getInput("ocaml-version");
-                    return [4 /*yield*/, installer.getOpam(ocamlVersion)];
+                    opamRepository = core.getInput("opam-repository");
+                    return [4 /*yield*/, installer.getOpam(ocamlVersion, opamRepository)];
                 case 1:
                     _a.sent();
                     return [3 /*break*/, 3];
@@ -4718,30 +4719,36 @@ function getOpamFileName(version) {
 function getOpamDownloadUrl(version, filename) {
     return util.format("https://github.com/ocaml/opam/releases/download/%s/%s", version, filename);
 }
-function acquireOpamWindows(version) {
+function acquireOpamWindows(version, custom_repository) {
     return __awaiter(this, void 0, void 0, function () {
-        var downloadPath, error_1, toolPath;
+        var repository, downloadPath, error_1, toolPath;
         return __generator(this, function (_a) {
             switch (_a.label) {
                 case 0:
-                    _a.trys.push([0, 2, , 3]);
-                    return [4 /*yield*/, tc.downloadTool("https://cygwin.com/setup-x86_64.exe")];
+                    repository = custom_repository === ""
+                        ? "https://github.com/fdopen/opam-repository-mingw.git#opam2"
+                        : custom_repository;
+                    _a.label = 1;
                 case 1:
-                    downloadPath = _a.sent();
-                    return [3 /*break*/, 3];
+                    _a.trys.push([1, 3, , 4]);
+                    return [4 /*yield*/, tc.downloadTool("https://cygwin.com/setup-x86_64.exe")];
                 case 2:
+                    downloadPath = _a.sent();
+                    return [3 /*break*/, 4];
+                case 3:
                     error_1 = _a.sent();
                     core.debug(error_1);
                     throw "Failed to download cygwin: " + error_1;
-                case 3: return [4 /*yield*/, tc.cacheFile(downloadPath, "setup-x86_64.exe", "cygwin", "1.0")];
-                case 4:
+                case 4: return [4 /*yield*/, tc.cacheFile(downloadPath, "setup-x86_64.exe", "cygwin", "1.0")];
+                case 5:
                     toolPath = _a.sent();
                     return [4 /*yield*/, exec_1.exec(__webpack_require__.ab + "install-ocaml-windows.cmd", [
                             __dirname,
                             toolPath,
                             version,
+                            repository,
                         ])];
-                case 5:
+                case 6:
                     _a.sent();
                     core.addPath("c:\\cygwin\\bin");
                     core.addPath("c:\\cygwin\\wrapperbin");
@@ -4750,15 +4757,18 @@ function acquireOpamWindows(version) {
         });
     });
 }
-function acquireOpamLinux(version) {
+function acquireOpamLinux(version, custom_repository) {
     return __awaiter(this, void 0, void 0, function () {
-        var opamVersion, fileName, downloadUrl, downloadPath, error_2, toolPath;
+        var opamVersion, fileName, downloadUrl, repository, downloadPath, error_2, toolPath;
         return __generator(this, function (_a) {
             switch (_a.label) {
                 case 0:
                     opamVersion = "2.0.5";
                     fileName = getOpamFileName(opamVersion);
                     downloadUrl = getOpamDownloadUrl(opamVersion, fileName);
+                    repository = custom_repository === ""
+                        ? "https://github.com/ocaml/opam-repository.git"
+                        : custom_repository;
                     _a.label = 1;
                 case 1:
                     _a.trys.push([1, 3, , 4]);
@@ -4779,11 +4789,7 @@ function acquireOpamLinux(version) {
                     return [4 /*yield*/, exec_1.exec("sudo apt-get -y install bubblewrap ocaml-native-compilers ocaml-compiler-libs musl-tools")];
                 case 6:
                     _a.sent();
-                    return [4 /*yield*/, exec_1.exec("\"" + toolPath + "/opam\"", [
-                            "init",
-                            "-yav",
-                            "https://github.com/ocaml/opam-repository.git",
-                        ])];
+                    return [4 /*yield*/, exec_1.exec("\"" + toolPath + "/opam\"", ["init", "-yav", repository])];
                 case 7:
                     _a.sent();
                     return [4 /*yield*/, exec_1.exec(__webpack_require__.ab + "install-ocaml-unix.sh", [version])];
@@ -4797,18 +4803,19 @@ function acquireOpamLinux(version) {
         });
     });
 }
-function acquireOpamDarwin(version) {
+function acquireOpamDarwin(version, custom_repository) {
     return __awaiter(this, void 0, void 0, function () {
+        var repository;
         return __generator(this, function (_a) {
             switch (_a.label) {
-                case 0: return [4 /*yield*/, exec_1.exec("brew", ["install", "opam"])];
+                case 0:
+                    repository = custom_repository === ""
+                        ? "https://github.com/ocaml/opam-repository.git"
+                        : custom_repository;
+                    return [4 /*yield*/, exec_1.exec("brew", ["install", "opam"])];
                 case 1:
                     _a.sent();
-                    return [4 /*yield*/, exec_1.exec("opam", [
-                            "init",
-                            "-yav",
-                            "https://github.com/ocaml/opam-repository.git",
-                        ])];
+                    return [4 /*yield*/, exec_1.exec("opam", ["init", "-yav", repository])];
                 case 2:
                     _a.sent();
                     return [4 /*yield*/, exec_1.exec(__webpack_require__.ab + "install-ocaml-unix.sh", [version])];
@@ -4822,16 +4829,16 @@ function acquireOpamDarwin(version) {
         });
     });
 }
-function getOpam(version) {
+function getOpam(version, repository) {
     return __awaiter(this, void 0, void 0, function () {
         return __generator(this, function (_a) {
             core.exportVariable("OPAMYES", "1");
             if (osPlat === "win32")
-                return [2 /*return*/, acquireOpamWindows(version)];
+                return [2 /*return*/, acquireOpamWindows(version, repository)];
             else if (osPlat === "darwin")
-                return [2 /*return*/, acquireOpamDarwin(version)];
+                return [2 /*return*/, acquireOpamDarwin(version, repository)];
             else if (osPlat === "linux")
-                return [2 /*return*/, acquireOpamLinux(version)];
+                return [2 /*return*/, acquireOpamLinux(version, repository)];
             return [2 /*return*/];
         });
     });

--- a/lib/install-ocaml-windows.cmd
+++ b/lib/install-ocaml-windows.cmd
@@ -2,7 +2,7 @@ set CYGWIN_ROOT=c:\cygwin
 %2/setup-x86_64.exe --quiet-mode --root %CYGWIN_ROOT% --site http://cygwin.mirror.constant.com --packages curl,diff,diffutils,git,m4,make,patch,perl,rsync,mingw64-x86_64-gcc-core,unzip
 set PATH=%CYGWIN_ROOT%\wrapperbin;%CYGWIN_ROOT%\bin;%PATH%
 dos2unix %1\install-ocaml-windows.sh
-bash -l %1\install-ocaml-windows.sh %3
+bash -l %1\install-ocaml-windows.sh %3 %4
 unix2dos %1\opam.bat
 mkdir %CYGWIN_ROOT%\wrapperbin
 copy %1\opam.bat %CYGWIN_ROOT%\wrapperbin\opam.bat

--- a/lib/install-ocaml-windows.sh
+++ b/lib/install-ocaml-windows.sh
@@ -8,6 +8,7 @@ if [ "$1" = "" ]; then
 else
   OCAML_VERSION="$1"
 fi
+OPAM_REPOSITORY="$2"
 SWITCH="${OCAML_VERSION}+mingw64c"
 OPAM_DL_SUB_LINK=0.0.0.2
 OPAM_URL="https://github.com/fdopen/opam-repository-mingw/releases/download/${OPAM_DL_SUB_LINK}/opam64.tar.xz"
@@ -29,7 +30,7 @@ case "$SWITCH" in
     eval "$(ocaml-env cygwin --ms=vs2015 --no-opam --64)"
     ;;
 esac
-opam init -c "ocaml-variants.${SWITCH}" --disable-sandboxing --enable-completion --enable-shell-hook --auto-setup default "https://github.com/fdopen/opam-repository-mingw.git#opam2"
+opam init -c "ocaml-variants.${SWITCH}" --disable-sandboxing --enable-completion --enable-shell-hook --auto-setup default "$OPAM_REPOSITORY"
 opam config set jobs "$OPAMJOBS"
 opam update
 is_msvc=0

--- a/src/install-ocaml-windows.cmd
+++ b/src/install-ocaml-windows.cmd
@@ -2,7 +2,7 @@ set CYGWIN_ROOT=c:\cygwin
 %2/setup-x86_64.exe --quiet-mode --root %CYGWIN_ROOT% --site http://cygwin.mirror.constant.com --packages curl,diff,diffutils,git,m4,make,patch,perl,rsync,mingw64-x86_64-gcc-core,unzip
 set PATH=%CYGWIN_ROOT%\wrapperbin;%CYGWIN_ROOT%\bin;%PATH%
 dos2unix %1\install-ocaml-windows.sh
-bash -l %1\install-ocaml-windows.sh %3
+bash -l %1\install-ocaml-windows.sh %3 %4
 unix2dos %1\opam.bat
 mkdir %CYGWIN_ROOT%\wrapperbin
 copy %1\opam.bat %CYGWIN_ROOT%\wrapperbin\opam.bat

--- a/src/install-ocaml-windows.sh
+++ b/src/install-ocaml-windows.sh
@@ -8,6 +8,7 @@ if [ "$1" = "" ]; then
 else
   OCAML_VERSION="$1"
 fi
+OPAM_REPOSITORY="$2"
 SWITCH="${OCAML_VERSION}+mingw64c"
 OPAM_DL_SUB_LINK=0.0.0.2
 OPAM_URL="https://github.com/fdopen/opam-repository-mingw/releases/download/${OPAM_DL_SUB_LINK}/opam64.tar.xz"
@@ -29,7 +30,7 @@ case "$SWITCH" in
     eval "$(ocaml-env cygwin --ms=vs2015 --no-opam --64)"
     ;;
 esac
-opam init -c "ocaml-variants.${SWITCH}" --disable-sandboxing --enable-completion --enable-shell-hook --auto-setup default "https://github.com/fdopen/opam-repository-mingw.git#opam2"
+opam init -c "ocaml-variants.${SWITCH}" --disable-sandboxing --enable-completion --enable-shell-hook --auto-setup default "$OPAM_REPOSITORY"
 opam config set jobs "$OPAMJOBS"
 opam update
 is_msvc=0

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -24,11 +24,11 @@ function getOpamDownloadUrl(version: string, filename: string) {
   );
 }
 
-async function acquireOpamWindows(version: string, custom_repository: string) {
+async function acquireOpamWindows(version: string, customRepository: string) {
   const repository =
-    custom_repository === ""
+    customRepository === ""
       ? "https://github.com/fdopen/opam-repository-mingw.git#opam2"
-      : custom_repository;
+      : customRepository;
   let downloadPath;
   try {
     downloadPath = await tc.downloadTool("https://cygwin.com/setup-x86_64.exe");
@@ -52,14 +52,14 @@ async function acquireOpamWindows(version: string, custom_repository: string) {
   core.addPath("c:\\cygwin\\wrapperbin");
 }
 
-async function acquireOpamLinux(version: string, custom_repository: string) {
+async function acquireOpamLinux(version: string, customRepository: string) {
   const opamVersion = "2.0.5";
   const fileName = getOpamFileName(opamVersion);
   const downloadUrl = getOpamDownloadUrl(opamVersion, fileName);
   const repository =
-    custom_repository === ""
+    customRepository === ""
       ? "https://github.com/ocaml/opam-repository.git"
-      : custom_repository;
+      : customRepository;
   let downloadPath;
   try {
     downloadPath = await tc.downloadTool(downloadUrl);
@@ -83,11 +83,11 @@ async function acquireOpamLinux(version: string, custom_repository: string) {
   await exec(`"${toolPath}/opam"`, ["install", "-y", "depext"]);
 }
 
-async function acquireOpamDarwin(version: string, custom_repository: string) {
+async function acquireOpamDarwin(version: string, customRepository: string) {
   const repository =
-    custom_repository === ""
+    customRepository === ""
       ? "https://github.com/ocaml/opam-repository.git"
-      : custom_repository;
+      : customRepository;
   await exec("brew", ["install", "opam"]);
   await exec("opam", ["init", "-yav", repository]);
   await exec(path.join(__dirname, "install-ocaml-unix.sh"), [version]);

--- a/src/setup-ocaml.ts
+++ b/src/setup-ocaml.ts
@@ -5,7 +5,8 @@ import * as installer from "./installer";
 async function run() {
   try {
     const ocamlVersion = core.getInput("ocaml-version");
-    await installer.getOpam(ocamlVersion);
+    const opamRepository = core.getInput("opam-repository");
+    await installer.getOpam(ocamlVersion, opamRepository);
   } catch (error) {
     core.setFailed(error.toString());
   }


### PR DESCRIPTION
When setting up github actions for [xen-api](https://github.com/xapi-project/xen-api/pull/4139) a post-install action to change the default repository was needed. This is because the default opam repository cannot be used to fetch its dependencies.

This PR adds a parameter to set a custom URL for the repository, similar to [ocaml-ci-scripts](https://github.com/ocaml/ocaml-ci-scripts) but without the separation between base remote and branch.

The most awkward part is not being able to set a per-platform default value on the action metadata. I've settled by an empty value by default that gets replaced by the platform default when running the action.

Regarding testing I thought about executing opam after installing, parse the list of repositories and check that the repository is there but the path of the executable varies by platform and it's tied to downloading opam, so it doesn't seem trivial to do. Are there any ideas?