### PR TITLE
Windows fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
-* text=auto eol=lf
+* text=auto
+*.sh text eol=lf
+*.cmd text eol=crlf
+*.bat text eol=crlf
 lib/* linguist-generated

--- a/lib/install-ocaml-windows.cmd
+++ b/lib/install-ocaml-windows.cmd
@@ -3,6 +3,7 @@ set CYGWIN_ROOT=c:\cygwin
 set PATH=%CYGWIN_ROOT%\wrapperbin;%CYGWIN_ROOT%\bin;%PATH%
 dos2unix %1\install-ocaml-windows.sh
 bash -l %1\install-ocaml-windows.sh %3 %4
+@if %ERRORLEVEL% neq 0 exit /b 1
 unix2dos %1\opam.bat
 mkdir %CYGWIN_ROOT%\wrapperbin
 copy %1\opam.bat %CYGWIN_ROOT%\wrapperbin\opam.bat

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "private": true,
   "scripts": {
-    "fmt": "prettier --write .",
-    "fmt:check": "prettier --check .",
+    "fmt": "prettier --end-of-line auto --write .",
+    "fmt:check": "prettier --end-of-line auto --check .",
     "lint": "eslint \"**/*.ts\" --cache",
     "test": "jest",
     "build:copy": "mkdir -p lib && shx cp src/*.{bat,cmd,sh} lib/",

--- a/src/install-ocaml-windows.cmd
+++ b/src/install-ocaml-windows.cmd
@@ -3,6 +3,7 @@ set CYGWIN_ROOT=c:\cygwin
 set PATH=%CYGWIN_ROOT%\wrapperbin;%CYGWIN_ROOT%\bin;%PATH%
 dos2unix %1\install-ocaml-windows.sh
 bash -l %1\install-ocaml-windows.sh %3 %4
+@if %ERRORLEVEL% neq 0 exit /b 1
 unix2dos %1\opam.bat
 mkdir %CYGWIN_ROOT%\wrapperbin
 copy %1\opam.bat %CYGWIN_ROOT%\wrapperbin\opam.bat


### PR DESCRIPTION
I added 4.11 to a matrix before fdopen had had a chance to update! The log is confusing, because the "Set-up OCaml" step claims to have succeeded (see [this log](https://github.com/metastack/bitmasks/runs/1004270846) from [this run](https://github.com/metastack/bitmasks/actions/runs/215591452) - note that the Unix and macOS ones fail at the "Set-up OCaml 4.12.0" step). Propagating the error in `install-ocaml-windows.cmd` gives the expected result in [this log](https://github.com/metastack/bitmasks/runs/1004252753). I switched it to 4.12 as upstream was actually updated while I was testing the fix.

I also updated `.gitattributes` - normalisation is good, but forcing Unix line-endings is rude (😉) and, at least for batch files, wrong.