### PR TITLE
Check if switch exists before creating

### DIFF
--- a/lib/install-ocaml-unix.sh
+++ b/lib/install-ocaml-unix.sh
@@ -7,6 +7,6 @@ set -ex
 
 CURRENT_OCAML=$(opam info -f version ocaml --color=never)
 
-if [ "$CURRENT_OCAML" != "$1" ] ; then
+if [ "$CURRENT_OCAML" != "$1" ]; then
   opam switch set "$1" || opam switch create "$1" "$1"
 fi

--- a/lib/install-ocaml-unix.sh
+++ b/lib/install-ocaml-unix.sh
@@ -6,8 +6,7 @@ set -ex
 # the right version from the system compiler
 
 CURRENT_OCAML=$(opam info -f version ocaml --color=never)
-SWITCHES=$(opam switch list)
 
-if [ "$CURRENT_OCAML" != "$1" ] && [ "$SWITCHES" != *"$1"* ]; then
-  opam switch create "$1" "$1"
+if [ "$CURRENT_OCAML" != "$1" ] ; then
+  opam switch set "$1" || opam switch create "$1" "$1"
 fi

--- a/lib/install-ocaml-unix.sh
+++ b/lib/install-ocaml-unix.sh
@@ -6,10 +6,8 @@ set -ex
 # the right version from the system compiler
 
 CURRENT_OCAML=$(opam info -f version ocaml --color=never)
+SWITCHES=$(opam switch list)
 
-opam switch list | $1
-STATUS=$?
-
-if [ "$CURRENT_OCAML" != "$1" ] && [ $STATUS -ne 0 ]; then
+if [ "$CURRENT_OCAML" != "$1" ] && [ "$SWITCHES" != *"$1"* ]; then
   opam switch create "$1" "$1"
 fi

--- a/lib/install-ocaml-unix.sh
+++ b/lib/install-ocaml-unix.sh
@@ -7,6 +7,9 @@ set -ex
 
 CURRENT_OCAML=$(opam info -f version ocaml --color=never)
 
-if [ "$CURRENT_OCAML" != "$1" ]; then
+opam switch list | $1
+STATUS=$?
+
+if [ "$CURRENT_OCAML" != "$1" ] && [ $STATUS -ne 0 ]; then
   opam switch create "$1" "$1"
 fi

--- a/src/install-ocaml-unix.sh
+++ b/src/install-ocaml-unix.sh
@@ -7,6 +7,6 @@ set -ex
 
 CURRENT_OCAML=$(opam info -f version ocaml --color=never)
 
-if [ "$CURRENT_OCAML" != "$1" ] ; then
+if [ "$CURRENT_OCAML" != "$1" ]; then
   opam switch set "$1" || opam switch create "$1" "$1"
 fi

--- a/src/install-ocaml-unix.sh
+++ b/src/install-ocaml-unix.sh
@@ -6,8 +6,7 @@ set -ex
 # the right version from the system compiler
 
 CURRENT_OCAML=$(opam info -f version ocaml --color=never)
-SWITCHES=$(opam switch list)
 
-if [ "$CURRENT_OCAML" != "$1" ] && [ "$SWITCHES" != *"$1"* ]; then
-  opam switch create "$1" "$1"
+if [ "$CURRENT_OCAML" != "$1" ] ; then
+  opam switch set "$1" || opam switch create "$1" "$1"
 fi

--- a/src/install-ocaml-unix.sh
+++ b/src/install-ocaml-unix.sh
@@ -6,10 +6,8 @@ set -ex
 # the right version from the system compiler
 
 CURRENT_OCAML=$(opam info -f version ocaml --color=never)
+SWITCHES=$(opam switch list)
 
-opam switch list | $1
-STATUS=$?
-
-if [ "$CURRENT_OCAML" != "$1" ] && [ $STATUS -ne 0 ]; then
+if [ "$CURRENT_OCAML" != "$1" ] && [ "$SWITCHES" != *"$1"* ]; then
   opam switch create "$1" "$1"
 fi

--- a/src/install-ocaml-unix.sh
+++ b/src/install-ocaml-unix.sh
@@ -7,6 +7,9 @@ set -ex
 
 CURRENT_OCAML=$(opam info -f version ocaml --color=never)
 
-if [ "$CURRENT_OCAML" != "$1" ]; then
+opam switch list | $1
+STATUS=$?
+
+if [ "$CURRENT_OCAML" != "$1" ] && [ $STATUS -ne 0 ]; then
   opam switch create "$1" "$1"
 fi


### PR DESCRIPTION
Hi!

I noticed that @smorimoto worked on caching on a separate repo and tried to integrate https://github.com/avsm/hello-world-action-ocaml/blob/with-cache/.github/workflows/workflow.yml in Opium (https://github.com/rgrinberg/opium/pull/183)

Unfortunately, it seems that caching the `~/.opam` directory does not work with multiple compilers at the moment because ocaml-setup uses `opam switch create` even if a switch with the same name already exists.

This PR adds a check that will only create a switch if it does not already exist. The check is really basic, maybe there's a better way to do this with opam?