### PR TITLE
Install Cygwin to the SSD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Windows installs Cygwin to D:\cygwin, using faster Azure temporary storage.
+
 ## [1.1.5] - 2020-12-15
 
 ### Changed

--- a/dist/index.js.cache.js
+++ b/dist/index.js.cache.js
@@ -5021,8 +5021,8 @@ function acquireOpamWindows(version, customRepository) {
                         ])];
                 case 6:
                     _a.sent();
-                    core.addPath("c:\\cygwin\\bin");
-                    core.addPath("c:\\cygwin\\wrapperbin");
+                    core.addPath("D:\\cygwin\\bin");
+                    core.addPath("D:\\cygwin\\wrapperbin");
                     return [2 /*return*/];
             }
         });

--- a/dist/install-ocaml-windows.cmd
+++ b/dist/install-ocaml-windows.cmd
@@ -1,4 +1,4 @@
-set CYGWIN_ROOT=c:\cygwin
+set CYGWIN_ROOT=D:\cygwin
 %2\setup-x86_64.exe --quiet-mode --root %CYGWIN_ROOT% --site http://cygwin.mirror.constant.com --packages curl,diff,diffutils,git,m4,make,patch,perl,rsync,mingw64-x86_64-gcc-core,mingw64-x86_64-gcc-g++,unzip
 copy %2\setup-x86_64.exe %CYGWIN_ROOT%
 set PATH=%CYGWIN_ROOT%\wrapperbin;%CYGWIN_ROOT%\bin;%PATH%

--- a/src/install-ocaml-windows.cmd
+++ b/src/install-ocaml-windows.cmd
@@ -1,4 +1,4 @@
-set CYGWIN_ROOT=c:\cygwin
+set CYGWIN_ROOT=D:\cygwin
 %2\setup-x86_64.exe --quiet-mode --root %CYGWIN_ROOT% --site http://cygwin.mirror.constant.com --packages curl,diff,diffutils,git,m4,make,patch,perl,rsync,mingw64-x86_64-gcc-core,mingw64-x86_64-gcc-g++,unzip
 copy %2\setup-x86_64.exe %CYGWIN_ROOT%
 set PATH=%CYGWIN_ROOT%\wrapperbin;%CYGWIN_ROOT%\bin;%PATH%

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -48,8 +48,8 @@ async function acquireOpamWindows(version: string, customRepository: string) {
     version,
     repository,
   ]);
-  core.addPath("c:\\cygwin\\bin");
-  core.addPath("c:\\cygwin\\wrapperbin");
+  core.addPath("D:\\cygwin\\bin");
+  core.addPath("D:\\cygwin\\wrapperbin");
 }
 
 async function acquireOpamLinux(version: string, customRepository: string) {


### PR DESCRIPTION
I haven't found documentation confirming the exact setup of the DSv2 Windows runners, but while working on a migration to GitHub Actions for OCaml, I discovered that the temporary storage drive (D: - 14GiB) is considerably faster than the system drive.

I tested this on one of my repos where the build itself is mere seconds. Before this change, setup-ocaml needed an average of 5:39 to install OCaml+opam and 1:53 to build the dependencies of the library. After this change, it needs an average of 3:15 for the installation and 1:27 for the deps.