### PR TITLE
Suppress error message if switch doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [unreleased]
 
+### Changed
+
+- Ubuntu and macOS runners no longer display "No switch is currently installed."
+  before building the compiler.
+
 ## [1.1.6]
 
 ### Changed

--- a/dist/install-ocaml-unix.sh
+++ b/dist/install-ocaml-unix.sh
@@ -8,5 +8,5 @@ set -ex
 CURRENT_OCAML=$(opam info -f version ocaml --color=never)
 
 if [ "$CURRENT_OCAML" != "$1" ]; then
-  opam switch set "$1" || opam switch create "$1" "$1"
+  opam switch set "$1" 2>/dev/null || opam switch create "$1" "$1"
 fi

--- a/src/install-ocaml-unix.sh
+++ b/src/install-ocaml-unix.sh
@@ -8,5 +8,5 @@ set -ex
 CURRENT_OCAML=$(opam info -f version ocaml --color=never)
 
 if [ "$CURRENT_OCAML" != "$1" ]; then
-  opam switch set "$1" || opam switch create "$1" "$1"
+  opam switch set "$1" 2>/dev/null || opam switch create "$1" "$1"
 fi


### PR DESCRIPTION
The command used to select the switch attempts to select it (caching) and then builds it if not. If the switch isn't there, there's a mildly intimidating error message from opam, before the script carries on to build the switch anyway. There's no need for the message...