### PR TITLE
Speed up the macOS and Ubuntu runners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
   before building the compiler.
 
 - Ubuntu no longer installs the system ocaml packages.
+- macOS no longer builds two compilers on every run.
 
 ## [1.1.6]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to
 
 - Ubuntu and macOS runners no longer display "No switch is currently installed."
   before building the compiler.
-
 - Ubuntu no longer installs the system ocaml packages.
 - macOS no longer builds two compilers on every run.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to
 - Ubuntu and macOS runners no longer display "No switch is currently installed."
   before building the compiler.
 
+- Ubuntu no longer installs the system ocaml packages.
+
 ## [1.1.6]
 
 ### Changed

--- a/dist/index.js
+++ b/dist/index.js
@@ -5055,7 +5055,7 @@ function acquireOpamLinux(version, customRepository) {
                 case 5:
                     toolPath = _a.sent();
                     core.addPath(toolPath);
-                    return [4 /*yield*/, exec_1.exec("sudo apt-get -y install bubblewrap ocaml-native-compilers ocaml-compiler-libs musl-tools")];
+                    return [4 /*yield*/, exec_1.exec("sudo apt-get -y install bubblewrap musl-tools")];
                 case 6:
                     _a.sent();
                     return [4 /*yield*/, exec_1.exec("\"" + toolPath + "/opam\"", ["init", "-yav", repository])];

--- a/dist/index.js
+++ b/dist/index.js
@@ -5058,7 +5058,7 @@ function acquireOpamLinux(version, customRepository) {
                     return [4 /*yield*/, exec_1.exec("sudo apt-get -y install bubblewrap musl-tools")];
                 case 6:
                     _a.sent();
-                    return [4 /*yield*/, exec_1.exec("\"" + toolPath + "/opam\"", ["init", "-yav", repository])];
+                    return [4 /*yield*/, exec_1.exec("\"" + toolPath + "/opam\"", ["init", "--bare", "-yav", repository])];
                 case 7:
                     _a.sent();
                     return [4 /*yield*/, exec_1.exec(__nccwpck_require__.ab + "install-ocaml-unix.sh", [version])];
@@ -5082,7 +5082,7 @@ function acquireOpamDarwin(version, customRepository) {
                     return [4 /*yield*/, exec_1.exec("brew", ["install", "opam"])];
                 case 1:
                     _a.sent();
-                    return [4 /*yield*/, exec_1.exec("opam", ["init", "-yav", repository])];
+                    return [4 /*yield*/, exec_1.exec("opam", ["init", "--bare", "-yav", repository])];
                 case 2:
                     _a.sent();
                     return [4 /*yield*/, exec_1.exec(__nccwpck_require__.ab + "install-ocaml-unix.sh", [version])];

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -74,9 +74,7 @@ async function acquireOpamLinux(version: string, customRepository: string) {
     opamVersion
   );
   core.addPath(toolPath);
-  await exec(
-    "sudo apt-get -y install bubblewrap musl-tools"
-  );
+  await exec("sudo apt-get -y install bubblewrap musl-tools");
   await exec(`"${toolPath}/opam"`, ["init", "--bare", "-yav", repository]);
   await exec(path.join(__dirname, "install-ocaml-unix.sh"), [version]);
   await exec(`"${toolPath}/opam"`, ["install", "-y", "depext"]);

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -75,7 +75,7 @@ async function acquireOpamLinux(version: string, customRepository: string) {
   );
   core.addPath(toolPath);
   await exec(
-    "sudo apt-get -y install bubblewrap ocaml-native-compilers ocaml-compiler-libs musl-tools"
+    "sudo apt-get -y install bubblewrap musl-tools"
   );
   await exec(`"${toolPath}/opam"`, ["init", "-yav", repository]);
   await exec(path.join(__dirname, "install-ocaml-unix.sh"), [version]);

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -77,7 +77,7 @@ async function acquireOpamLinux(version: string, customRepository: string) {
   await exec(
     "sudo apt-get -y install bubblewrap musl-tools"
   );
-  await exec(`"${toolPath}/opam"`, ["init", "-yav", repository]);
+  await exec(`"${toolPath}/opam"`, ["init", "--bare", "-yav", repository]);
   await exec(path.join(__dirname, "install-ocaml-unix.sh"), [version]);
   await exec(`"${toolPath}/opam"`, ["install", "-y", "depext"]);
 }
@@ -87,7 +87,7 @@ async function acquireOpamDarwin(version: string, customRepository: string) {
     customRepository || "https://github.com/ocaml/opam-repository.git";
 
   await exec("brew", ["install", "opam"]);
-  await exec("opam", ["init", "-yav", repository]);
+  await exec("opam", ["init", "--bare", "-yav", repository]);
   await exec(path.join(__dirname, "install-ocaml-unix.sh"), [version]);
   await exec("opam", ["install", "-y", "depext"]);
 }


### PR DESCRIPTION
Two changes:

- Cease installing the `ocaml-native-compilers` and `ocaml-compiler-libs` Ubuntu packages. On the runners where the version in Ubuntu (4.05 in 18.04, 4.08 in 20.04) this is a "waste" of time. It's also not brilliant to be randomly using ocaml-system on the package which happens to match. Technically this therefore slows down any 4.05 builds. This is a relatively small adjustment.
- The macOS runners are building OCaml twice - they all build 4.11.1 at `opam init` and then, even on 4.11.1, discard that compiler later on.

`opam init --bare` sets up opam without creating an initial switch... on macOS, this shaves several minutes off the build times.