### PR TITLE
Two more tiny tweaks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
 * text=auto
 *.sh text eol=lf
 *.cmd text eol=crlf
-lib/* linguist-generated
+dist/** -diff linguist-generated

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -31,12 +31,6 @@ jobs:
       - name: Install npm packages
         run: yarn --frozen-lockfile
 
-      - name: Check formatting
-        run: yarn fmt:check
-
-      - name: Check lint
-        run: yarn lint
-
       - name: Check type
         run: yarn typecheck
 
@@ -57,3 +51,11 @@ jobs:
           ocaml-version: ${{ matrix.ocaml-version }}
 
       - run: opam depext yaml --install --verbose --yes
+
+      - name: Check formatting
+        run: yarn fmt:check
+        if: always()
+
+      - name: Check lint
+        run: yarn lint
+        if: always()


### PR DESCRIPTION
Linting and formatting are important, but it's tedious to lose a run to a mis-formatted line - put the lint checks _after_ actually running the code and always run both of them (technically speaking they'll go haywire if something went wrong installing yarn...)

The `linguist-generated` attribute was pointing to the old `lib` directory.