### PR TITLE
Remove opam config set jobs from Windows runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [unreleased]
 
+- Stop setting switch jobs variable on Windows (`OPAMJOBS` is sufficient).
+
 ## [1.1.10]
 
 ### Changed

--- a/dist/install-ocaml-windows.sh
+++ b/dist/install-ocaml-windows.sh
@@ -31,7 +31,6 @@ case "$SWITCH" in
     ;;
 esac
 opam init -c "ocaml-variants.${SWITCH}" --disable-sandboxing --enable-completion --enable-shell-hook --auto-setup default "$OPAM_REPOSITORY"
-opam config set jobs "$OPAMJOBS"
 opam update
 is_msvc=0
 case "$SWITCH" in

--- a/src/install-ocaml-windows.sh
+++ b/src/install-ocaml-windows.sh
@@ -31,7 +31,6 @@ case "$SWITCH" in
     ;;
 esac
 opam init -c "ocaml-variants.${SWITCH}" --disable-sandboxing --enable-completion --enable-shell-hook --auto-setup default "$OPAM_REPOSITORY"
-opam config set jobs "$OPAMJOBS"
 opam update
 is_msvc=0
 case "$SWITCH" in


### PR DESCRIPTION
This sets a switch variable, not the the global, which is surprising if you run `opam -j 1 install` as `%{jobs}%` is still 3. Given that `OPAMJOBS` is always set in the environment, I don't think there's any need to do this.

(FWIW I think it should have been `opam config set-global jobs`, but as I say I don't think it's needed at all)